### PR TITLE
Updated ASR.xml

### DIFF
--- a/ASR/sitecore modules/Shell/ASR/ASR.xml
+++ b/ASR/sitecore modules/Shell/ASR/ASR.xml
@@ -8,7 +8,7 @@
 
 <control xmlns:def="Definition" xmlns="http://schemas.sitecore.net/Visual-Studio-Intellisense">
 	<ASR>
-		<FormPage Height="250px">            
+		<FormPage Height="250px" Scroll="yes">            
             <Stylesheet Src="Ribbon.css" DeviceDependant="true" runat="server" />
 
             <CodeBeside Type="ASR.App.MainForm,ASR"/>


### PR DESCRIPTION
There is an issue with the reporter results view in IE11, there is no way to scroll the results.
As a workaround I have updated ASR.xml and added Scroll="yes" to the FormPage element. Which allows overflown frame to be scrolled.
